### PR TITLE
Update bancho routes

### DIFF
--- a/app/peppy/common.go
+++ b/app/peppy/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/osuAkatsuki/akatsuki-api/common"
 	"github.com/valyala/fasthttp"
+	"gopkg.in/redis.v5"
 )
 
 var modes = []string{"std", "taiko", "ctb", "mania"}
@@ -72,4 +73,13 @@ func json(c *fasthttp.RequestCtx, code int, data interface{}) {
 		panic(err)
 	}
 	c.Write(d)
+}
+
+func leaderboardPosition(r *redis.Client, key string, user int) *int {
+	res := r.ZRevRank(key, strconv.Itoa(user))
+	if res.Err() == redis.Nil {
+		return nil
+	}
+	x := int(res.Val()) + 1
+	return &x
 }

--- a/app/peppy/common.go
+++ b/app/peppy/common.go
@@ -26,10 +26,6 @@ func genmodei(m string) int {
 	}
 	return v
 }
-func rankable(m string) bool {
-	x := genmodei(m)
-	return x != 2
-}
 
 func genUser(c *fasthttp.RequestCtx, db *sqlx.DB) (string, string) {
 	var whereClause string

--- a/app/peppy/score.go
+++ b/app/peppy/score.go
@@ -16,10 +16,12 @@ import (
 
 // GetScores retrieve information about the top 100 scores of a specified beatmap.
 func GetScores(c *fasthttp.RequestCtx, db *sqlx.DB) {
-	if query(c, "b") == "" {
+	args := c.QueryArgs()
+	if !args.Has("b") {
 		json(c, 200, defaultResponse)
 		return
 	}
+
 	var beatmapMD5 string
 	err := db.Get(&beatmapMD5, "SELECT beatmap_md5 FROM beatmaps WHERE beatmap_id = ? LIMIT 1", query(c, "b"))
 	switch {
@@ -32,23 +34,25 @@ func GetScores(c *fasthttp.RequestCtx, db *sqlx.DB) {
 		return
 	}
 
-	rx := query(c, "rx")
+	rx := common.Int(query(c, "rx"))
 
 	table := "scores"
 	switch rx {
-	case "1", "true", "True":
+	case 1:
 		table = "scores_relax"
+	case 2:
+		table = "scores_ap"
 	}
-	fmt.Println(table)
+
 	var sb = table + ".score"
-	if rankable(query(c, "m")) {
+	if rx != 0 {
 		sb = table + ".pp"
 	}
 	var (
 		extraWhere  string
 		extraParams []interface{}
 	)
-	if query(c, "u") != "" {
+	if args.Has("u") {
 		w, p := genUser(c, db)
 		extraWhere = "AND " + w
 		extraParams = append(extraParams, p)

--- a/app/peppy/score.go
+++ b/app/peppy/score.go
@@ -34,7 +34,12 @@ func GetScores(c *fasthttp.RequestCtx, db *sqlx.DB) {
 		return
 	}
 
-	rx := common.Int(query(c, "rx"))
+	relax := query(c, "rx")
+	if relax == "" {
+		relax = "0"
+	}
+
+	rx := common.Int(relax)
 
 	table := "scores"
 	switch rx {

--- a/app/peppy/score.go
+++ b/app/peppy/score.go
@@ -39,18 +39,16 @@ func GetScores(c *fasthttp.RequestCtx, db *sqlx.DB) {
 		relax = "0"
 	}
 
-	rx := common.Int(relax)
-
 	table := "scores"
-	switch rx {
-	case 1:
+	switch relax {
+	case "1", "true", "True":
 		table = "scores_relax"
-	case 2:
+	case "2":
 		table = "scores_ap"
 	}
 
 	var sb = table + ".score"
-	if rx != 0 {
+	if relax != "0" {
 		sb = table + ".pp"
 	}
 	var (


### PR DESCRIPTION
- looking up the query params is now done properly using Has function
- parseDiffName method is rewritten to use regex instead of buggy splitting strings
- implemented autopilot support along with removing very old legacy stuff (relax was still triggered by rx=True)
- fixed join date not showing in api at all
- did checks to see if user requested relax or autopilot data, modifying queries to match relax/autopilot changes