### PR TITLE
Add hypothetical rank endpoint

### DIFF
--- a/app/start.go
+++ b/app/start.go
@@ -102,6 +102,7 @@ func Start(dbO *sqlx.DB) *fhr.Router {
 		r.Method("/api/v1/scores", v1.ScoresGET)
 		r.Method("/api/v1/beatmaps/rank_requests/status", v1.BeatmapRankRequestsStatusGET)
 		r.Method("/api/v1/countries", v1.CountriesGET)
+		r.Method("/api/v1/hypothetical-rank", v1.HypotheticalRankGET)
 
 		// ReadConfidential privilege required
 		r.Method("/api/v1/friends", v1.FriendsGET, common.PrivilegeReadConfidential)

--- a/app/v1/rank.go
+++ b/app/v1/rank.go
@@ -1,0 +1,73 @@
+package v1
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/osuAkatsuki/akatsuki-api/common"
+	redis "gopkg.in/redis.v5"
+)
+
+type hypotheticalRankResponse struct {
+	common.ResponseBase
+	Rank int `json:"rank"`
+}
+
+func HypotheticalRankGET(md common.MethodData) common.CodeMessager {
+	modeInt, err := strconv.Atoi(md.Query("mode"))
+	if err != nil || modeInt > 3 || modeInt < 0 {
+		return common.SimpleResponse(400, "invalid mode")
+	}
+
+	mode := modesToReadable[modeInt]
+
+	rx, err := strconv.Atoi(md.Query("rx"))
+	if err != nil || rx > 2 || rx < 0 {
+		return common.SimpleResponse(400, "invalid relax int")
+	}
+
+	performancePoints, err := strconv.Atoi(md.Query("pp"))
+	if err != nil || performancePoints < 0 {
+		return common.SimpleResponse(400, "invalid performance points")
+	}
+
+	var rank *int
+	if rx == 0 {
+		rank = rankAtPerformancePoints(md.R, mode, performancePoints)
+	} else if rx == 1 {
+		rank = relaxRankAtPerformancePoints(md.R, mode, performancePoints)
+	} else if rx == 2 {
+		rank = autopilotRankAtPerformancePoints(md.R, mode, performancePoints)
+	}
+
+	if rank == nil {
+		return common.SimpleResponse(500, "failed to calculate hypothetical rank")
+	}
+
+	resp := hypotheticalRankResponse{
+		Rank: *rank,
+	}
+	resp.Code = 200
+	return resp
+}
+
+func rankAtPerformancePoints(r *redis.Client, mode string, performancePoints int) *int {
+	return _rankAtPerformancePoints(r, "ripple:leaderboard:"+mode, performancePoints)
+}
+
+func relaxRankAtPerformancePoints(r *redis.Client, mode string, performancePoints int) *int {
+	return _rankAtPerformancePoints(r, "ripple:relaxboard:"+mode, performancePoints)
+}
+
+func autopilotRankAtPerformancePoints(r *redis.Client, mode string, performancePoints int) *int {
+	return _rankAtPerformancePoints(r, "ripple:autoboard:"+mode, performancePoints)
+}
+
+func _rankAtPerformancePoints(r *redis.Client, key string, performancePoints int) *int {
+	res := r.ZCount(key, fmt.Sprintf("(%s", strconv.Itoa(performancePoints)), "inf")
+	if res.Err() == redis.Nil {
+		return nil
+	}
+	x := int(res.Val()) + 1
+	return &x
+}

--- a/app/v1/rank.go
+++ b/app/v1/rank.go
@@ -66,7 +66,7 @@ func autopilotRankAtPerformancePoints(r *redis.Client, mode string, performanceP
 }
 
 func _rankAtPerformancePoints(r *redis.Client, key string, performancePoints int) (int, error) {
-	res := r.ZCount(key, fmt.Sprintf("(%i", performancePoints), "inf")
+	res := r.ZCount(key, fmt.Sprintf("(%d", performancePoints), "inf")
 	err := res.Err()
 	if err != nil {
 		return -1, err

--- a/app/v1/rank.go
+++ b/app/v1/rank.go
@@ -69,7 +69,7 @@ func _rankAtPerformancePoints(r *redis.Client, key string, performancePoints int
 	res := r.ZCount(key, fmt.Sprintf("(%s", strconv.Itoa(performancePoints)), "inf")
 	err := res.Err()
 	if err != nil {
-		return -1, nil
+		return -1, err
 	}
 
 	x := int(res.Val()) + 1

--- a/app/v1/rank.go
+++ b/app/v1/rank.go
@@ -66,7 +66,7 @@ func autopilotRankAtPerformancePoints(r *redis.Client, mode string, performanceP
 }
 
 func _rankAtPerformancePoints(r *redis.Client, key string, performancePoints int) (int, error) {
-	res := r.ZCount(key, fmt.Sprintf("(%s", strconv.Itoa(performancePoints)), "inf")
+	res := r.ZCount(key, fmt.Sprintf("(%i", performancePoints), "inf")
 	err := res.Err()
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
idea is you feed the endpoint your desired mode, relax int and performance points and returns what rank that pp would be if it were on the leaderboard. requested for discord bot use, these are pretty common (osudaily is used for bancho calculations)

example of how this redis query works against the leaderboard:
![image](https://github.com/osuAkatsuki/akatsuki-api/assets/51536154/dd8e3edd-1fe2-491b-9162-52b6aa878bcb)
![image](https://github.com/osuAkatsuki/akatsuki-api/assets/51536154/4feae772-cde3-4ff8-a8b5-32a05ac1e7c2)

in case you're unfamiliar with ranges, the `(` is to start the range and be exclusive of the same number - we don't care if someone has the same pp, only if they are above

the result of the `ZCOUNT` query is how many users there are above that pp. we add 1 to get the rank, same way we add 1 to the result of `ZREVRANK`