### PR TITLE
lowercase country name in GET leaderboard for consistency

### DIFF
--- a/app/v1/leaderboard.go
+++ b/app/v1/leaderboard.go
@@ -102,7 +102,7 @@ func LeaderboardGET(md common.MethodData) common.CodeMessager {
 		key = "ripple:autoboard:" + m
 	}
 	if md.Query("country") != "" {
-		key += ":" + md.Query("country")
+		key += ":" + strings.ToLower(md.Query("country"))
 	}
 
 	results, err := md.R.ZRevRange(key, int64(p*l), int64(p*l+l-1)).Result()


### PR DESCRIPTION
These functions already do this:
![image](https://github.com/user-attachments/assets/e7fef632-e828-40ff-8745-c605e6d573e5)
