### PR TITLE
return 400 instead of panicking on bad score id

### DIFF
--- a/app/v1/user_scores.go
+++ b/app/v1/user_scores.go
@@ -182,7 +182,7 @@ func ScoresPinAddPOST(md common.MethodData) common.CodeMessager {
 
 	id, err := strconv.ParseInt(u.ID, 10, 64)
 	if err != nil {
-		panic(err)
+		return common.SimpleResponse(400, "invalid score id")
 	}
 
 	return pinScore(md, id, u.Relax, md.ID())
@@ -201,7 +201,7 @@ func ScoresPinDelPOST(md common.MethodData) common.CodeMessager {
 
 	id, err := strconv.ParseInt(u.ID, 10, 64)
 	if err != nil {
-		panic(err)
+		return common.SimpleResponse(400, "invalid score id")
 	}
 
 	return unpinScore(md, id, u.Relax, md.ID())


### PR DESCRIPTION
Fixes #96

strconv.ParseInt errors now return a 400 response instead of crashing.