### PR TITLE
add defer rows.Close() to query results in user.go

### DIFF
--- a/app/v1/user.go
+++ b/app/v1/user.go
@@ -467,6 +467,7 @@ func UserFullGET(md common.MethodData) common.CodeMessager {
 	if err != nil {
 		md.Err(err)
 	}
+	defer rows.Close()
 	for rows.Next() {
 		err := rows.Scan(&follower)
 		if err != nil {
@@ -481,6 +482,7 @@ func UserFullGET(md common.MethodData) common.CodeMessager {
 	if err != nil {
 		md.Err(err)
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var badge singleBadge
@@ -503,6 +505,7 @@ func UserFullGET(md common.MethodData) common.CodeMessager {
 	if err != nil {
 		md.Err(err)
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var Tbadge TsingleBadge


### PR DESCRIPTION
Fixes #98

Three db.Query calls (followers, badges, tournament badges) never closed the rows object. Leaks connections under load.