### PR TITLE
fix private match access check logic

### DIFF
--- a/app/v1/match.go
+++ b/app/v1/match.go
@@ -179,7 +179,7 @@ func MatchGET(md common.MethodData) common.CodeMessager {
 	}
 
 	if privateMatch &&
-		(!inList(participantsIds, md.User.ID) ||
+		(!inList(participantsIds, md.User.ID) &&
 			md.User.UserPrivileges&common.UserPrivilegeTournamentStaff == 0) {
 		return common.SimpleResponse(404, "That match could not be found!")
 	}


### PR DESCRIPTION
Fixes #97

Changed || to && so access is denied only when the user is neither a participant nor tournament staff. The old logic required both.