### PR TITLE
Log client IP in request access logs

### DIFF
--- a/app/router.go
+++ b/app/router.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/buaazp/fasthttprouter"
@@ -35,10 +36,8 @@ func (r router) PlainGET(path string, handle fasthttp.RequestHandler) {
 const (
 	// \x1b is escape code for ESC
 	// <ESC>[<n>m is escape sequence for a certain colour
-	// no IP is written out because of the hundreds of possible ways to pass IPs
-	// to a request when using a reverse proxy
 	// this is partly inspired from gin, though made even more simplistic.
-	fmtString = "%s | %15s |\x1b[%sm %3d \x1b[0m %-7s %s\n"
+	fmtString = "%s | %15s | %-15s |\x1b[%sm %3d \x1b[0m %-7s %s\n"
 	// a kind of human readable RFC3339
 	timeFormat = "2006-01-02 15:04:05"
 	// color reference
@@ -46,6 +45,24 @@ const (
 	colorOk    = "42" // green
 	colorError = "41" // red
 )
+
+// clientIP extracts the real client IP from the request, honouring
+// X-Real-IP / X-Forwarded-For set by the reverse proxy.
+func clientIP(c *fasthttp.RequestCtx) string {
+	ip := strings.TrimSpace(string(c.Request.Header.Peek("X-Real-Ip")))
+	if len(ip) > 0 {
+		return ip
+	}
+	ip = string(c.Request.Header.Peek("X-Forwarded-For"))
+	if index := strings.IndexByte(ip, ','); index >= 0 {
+		ip = ip[0:index]
+	}
+	ip = strings.TrimSpace(ip)
+	if len(ip) > 0 {
+		return ip
+	}
+	return c.RemoteIP().String()
+}
 
 // wrap returns a function that wraps around handle, providing middleware
 // functionality to apply to all API calls, which is to say:
@@ -92,6 +109,7 @@ func wrap(handle fasthttp.RequestHandler) fasthttp.RequestHandler {
 				fmtString,
 				time.Now().Format(timeFormat),
 				time.Since(start).String(),
+				clientIP(c),
 				color,
 				statusCode,
 				c.Method(),


### PR DESCRIPTION
## Summary
- Include the client IP in the per-request access log line emitted by the `wrap` middleware.
- Extracts the IP from `X-Real-IP` → first hop of `X-Forwarded-For` → `RemoteIP()`, mirroring the existing `MethodData.ClientIP()` helper.

The old "no IP is written out because of the hundreds of possible ways to pass IPs" caveat no longer applies: our nginx config (`hetzner-infra/config/nginx/sites-enabled/frontend.conf`) sets `X-Real-IP $http_CF_Connecting_IP` on the `/api/` upstream, so a single header is authoritative.

## Test plan
- [ ] Build passes (`go build ./...`).
- [ ] Hit an endpoint through the production reverse proxy and confirm the logged IP matches the real client (not the proxy).
- [ ] Hit the service directly (no proxy) and confirm it falls back to `RemoteAddr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)