### PR TITLE
Fix BBCode template import

### DIFF
--- a/externals/bbcode.go
+++ b/externals/bbcode.go
@@ -2,6 +2,7 @@ package externals
 
 import (
 	"fmt"
+	"html/template"
 	"math/rand"
 	"net/url"
 	"regexp"


### PR DESCRIPTION
## Summary
- import html/template for BBCode image escaping

## Verification
- go build
- docker build -t akatsuki-api:ci-fix-check .