### PR TITLE
Validate OAuth state for connection callbacks

### DIFF
--- a/app/v1/connections.go
+++ b/app/v1/connections.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/osuAkatsuki/akatsuki-api/common"
@@ -30,6 +31,10 @@ func DiscordCallbackGET(md common.MethodData) common.CodeMessager {
 	code := md.Query("code")
 	if code == "" {
 		return ErrBadJSON
+	}
+
+	if r := validateOAuthState(md, "discord"); r != nil {
+		return r
 	}
 
 	if md.DB.QueryRow("SELECT 1 FROM users WHERE id = ? AND discord_account_id IS NOT NULL", md.ID()).
@@ -118,6 +123,10 @@ func TwitchCallbackGET(md common.MethodData) common.CodeMessager {
 	code := md.Query("code")
 	if code == "" {
 		return ErrBadJSON
+	}
+
+	if r := validateOAuthState(md, "twitch"); r != nil {
+		return r
 	}
 
 	if md.DB.QueryRow("SELECT 1 FROM users WHERE id = ? AND twitch_account_id IS NOT NULL", md.ID()).
@@ -225,4 +234,23 @@ func TwitchCallbackGET(md common.MethodData) common.CodeMessager {
 
 	md.Ctx.Redirect("https://akatsuki.gg/settings/connections", 301)
 	return common.SimpleResponse(301, "")
+}
+
+func validateOAuthState(md common.MethodData, provider string) common.CodeMessager {
+	settings := common.GetSettings()
+	state := md.Query("state")
+	if state == "" {
+		return common.SimpleResponse(400, "Missing OAuth state. Please try linking your account again.")
+	}
+
+	userID, err := common.ValidateOAuthState(state, provider, settings.HANAYO_KEY, time.Now())
+	if err != nil {
+		return common.SimpleResponse(400, common.OAuthStateValidationMessage(err))
+	}
+
+	if userID != md.ID() {
+		return common.SimpleResponse(400, common.OAuthStateValidationMessage(common.ErrInvalidOAuthState))
+	}
+
+	return nil
 }

--- a/common/oauth_state.go
+++ b/common/oauth_state.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+type OAuthState struct {
+	Provider  string `json:"provider"`
+	UserID    int    `json:"user_id"`
+	ExpiresAt int64  `json:"expires_at"`
+	Nonce     string `json:"nonce"`
+}
+
+var (
+	ErrInvalidOAuthState = errors.New("invalid oauth state")
+	ErrExpiredOAuthState = errors.New("expired oauth state")
+)
+
+func ValidateOAuthState(
+	rawState string,
+	expectedProvider string,
+	secret string,
+	now time.Time,
+) (int, error) {
+	parts := strings.Split(rawState, ".")
+	if len(parts) != 3 || parts[0] != "v1" {
+		return 0, ErrInvalidOAuthState
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0, ErrInvalidOAuthState
+	}
+
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return 0, ErrInvalidOAuthState
+	}
+
+	if !hmac.Equal(signature, signOAuthState(parts[0]+"."+parts[1], secret)) {
+		return 0, ErrInvalidOAuthState
+	}
+
+	var state OAuthState
+	if err := json.Unmarshal(payloadBytes, &state); err != nil {
+		return 0, ErrInvalidOAuthState
+	}
+
+	if state.Provider != expectedProvider || state.UserID <= 0 || state.Nonce == "" {
+		return 0, ErrInvalidOAuthState
+	}
+
+	if now.Unix() > state.ExpiresAt {
+		return 0, ErrExpiredOAuthState
+	}
+
+	return state.UserID, nil
+}
+
+func signOAuthState(value string, secret string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(value))
+	return mac.Sum(nil)
+}
+
+func OAuthStateValidationMessage(err error) string {
+	if errors.Is(err, ErrExpiredOAuthState) {
+		return "OAuth state has expired. Please try linking your account again."
+	}
+
+	return "Invalid OAuth state. Please try linking your account again."
+}

--- a/common/oauth_state_test.go
+++ b/common/oauth_state_test.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func testOAuthState(
+	t *testing.T,
+	provider string,
+	userID int,
+	expiresAt int64,
+) string {
+	t.Helper()
+
+	payload, err := json.Marshal(OAuthState{
+		Provider:  provider,
+		UserID:    userID,
+		ExpiresAt: expiresAt,
+		Nonce:     "test-nonce",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signedValue := "v1." + encodedPayload
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write([]byte(signedValue))
+
+	return signedValue + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestValidateOAuthState(t *testing.T) {
+	rawState := testOAuthState(t, "discord", 123, 200)
+
+	userID, err := ValidateOAuthState(rawState, "discord", "secret", time.Unix(100, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if userID != 123 {
+		t.Fatalf("expected user id 123, got %d", userID)
+	}
+}
+
+func TestValidateOAuthStateRejectsWrongProvider(t *testing.T) {
+	rawState := testOAuthState(t, "discord", 123, 200)
+
+	_, err := ValidateOAuthState(rawState, "twitch", "secret", time.Unix(100, 0))
+	if err != ErrInvalidOAuthState {
+		t.Fatalf("expected ErrInvalidOAuthState, got %v", err)
+	}
+}
+
+func TestValidateOAuthStateRejectsExpiredState(t *testing.T) {
+	rawState := testOAuthState(t, "discord", 123, 200)
+
+	_, err := ValidateOAuthState(rawState, "discord", "secret", time.Unix(201, 0))
+	if err != ErrExpiredOAuthState {
+		t.Fatalf("expected ErrExpiredOAuthState, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add signed OAuth state validation for connection callbacks
- require matching state for Discord and Twitch callback handlers
- reject missing, invalid, expired, or wrong-user state before linking accounts

## Provider support checked
- Discord docs support and recommend state for OAuth2 CSRF protection
- Twitch authorization-code docs support and strongly encourage state for CSRF protection

## Tests
- go test common/oauth_state.go common/oauth_state_test.go
- go test ./app/v1

Note: go test ./common is currently blocked on master by common/where_test.go using []string against a [][]byte API; this PR does not touch that test.