### PR TITLE
Redirect Discord linking to connections page

### DIFF
--- a/app/v1/connections.go
+++ b/app/v1/connections.go
@@ -93,7 +93,7 @@ func DiscordCallbackGET(md common.MethodData) common.CodeMessager {
 
 	md.DB.Exec("UPDATE users SET discord_account_id = ? WHERE id = ?", discordUser.ID, md.ID())
 
-	md.Ctx.Redirect("https://akatsuki.gg", 302)
+	md.Ctx.Redirect("https://akatsuki.gg/settings/connections", 302)
 	return common.SimpleResponse(302, "")
 }
 


### PR DESCRIPTION
## Summary
- redirect successful Discord account linking back to /settings/connections
- match the existing Twitch and osu! linking redirects

## Tests
- go test ./app/v1